### PR TITLE
Refactor to return Stream type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "type_pubsub"
 description = "Type-based publisher-subscriber broker written in Rust"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license-file = "LICENSE-APACHE"
 readme = "README.md"


### PR DESCRIPTION
Previously, the subscribe method expected the user to pass a sending end
of a tokio channel which would be used to send updates to the
subscriber.

With this refactor, the subscribe method creates a pair of sender and
receiver for an unbound channel of the `futures` crate. It returns the
type `PubSubStream` which implements `Stream`.

The example binary and the function to create an echo client were
rewritten accordingly.